### PR TITLE
Fix hint in 06

### DIFF
--- a/notebooks/06_backfilling_reviews.livemd
+++ b/notebooks/06_backfilling_reviews.livemd
@@ -236,7 +236,7 @@ assert_enqueued worker: ChowMojo.SentimentAnalyzer, priority: 3
 Then modify `enqueue_backfill`:
 
 ```elixir
-|> Enum.map(&ChowMojo.SentimentAnalyzer.new(%{id: &1}), priority: 3)
+|> Enum.map(&ChowMojo.SentimentAnalyzer.new(%{id: &1}, priority: 3))
 ```
 
 </details>


### PR DESCRIPTION
Wrong (`priority` belongs to `new()`, not to `Enum.map/2`):
```elixir
Enum.map(&ChowMojo.SentimentAnalyzer.new(%{id: &1}), priority: 3)
```

Correct:
```elixir
Enum.map(&ChowMojo.SentimentAnalyzer.new(%{id: &1}, priority: 3))
```