### PR TITLE
Fix hint to match on order cancelled state

### DIFF
--- a/notebooks/03_placing_an_order.livemd
+++ b/notebooks/03_placing_an_order.livemd
@@ -294,6 +294,8 @@ def perform(%Job{args: %{"id" => order_id}}) do
       {:error, 429, _} -> {:snooze, 10}
       {:error, status, body} -> {:error, {status, body}}
     end
+  else
+    {state, msg} -> {state, msg}
   end
 end
 


### PR DESCRIPTION
The `with` was matching only on the `{:ok, order}` tuple and not matching on an error case to return the canceled tuple