### PR TITLE
update links to last doc version

### DIFF
--- a/notebooks/01_up_and_running.livemd
+++ b/notebooks/01_up_and_running.livemd
@@ -192,7 +192,7 @@ Use `psql` (Postgres console) or another database explorer tool to look at the t
 
 #### Inspect the running Oban supervision tree
 
-Look at which processes are running under the `Oban` instance's supervision tree either through beam tooling, the registry, or browsing the [source code](https://github.com/sorentwo/oban/blob/main/lib/oban.ex#L257).
+Look at which processes are running under the `Oban` instance's supervision tree either through beam tooling, the registry, or browsing the [source code](https://github.com/sorentwo/oban/blob/main/lib/oban.ex#L483).
 
 1. What are the direct children of the Oban supervisor?
 2. Which process handles running queues?

--- a/notebooks/02_signing_up.livemd
+++ b/notebooks/02_signing_up.livemd
@@ -194,7 +194,7 @@ ExUnit.run()
 
 Once the `WelcomeWorker` job executes successfully you'll see one test pass with zero failures. You've exercised the full welcome flow within the test process, without touching the database! Now we'll write another test using the helpers provided by `Oban.Testing` to assert that the job is enqueued in the database properly.
 
-In this test the testing mode is already set to `:manual`. [Setup the testing helpers](https://hexdocs.pm/oban/testing.html#setup-testing-helpers), then use [`assert_enqueued/1`](https://hexdocs.pm/oban/Oban.Testing.html#module-using-in-tests) to verify the job is enqueued.
+In this test the testing mode is already set to `:manual`. [Setup the testing helpers](https://hexdocs.pm/oban/testing.html#setup-testing-helpers), then use [`assert_enqueued/1`](https://hexdocs.pm/oban/Oban.Testing.html#module-usage) to verify the job is enqueued.
 
 <details>
 <summary><i>Use a Hint</i></summary>
@@ -241,7 +241,7 @@ Create another worker and deliver a follow-up job one day in the future after us
 
 1. Use the `schedule_in` option to delay job execution until a later time
 2. Try using the `{:days, N}` shorthand rather than calculating using raw seconds
-3. Write a test to verify the email is [scheduled for delivery in the future](https://hexdocs.pm/oban/Oban.Testing.html#module-matching-scheduled-jobs-and-timestamps)
+3. Write a test to verify the email is [scheduled for delivery in the future](https://hexdocs.pm/oban/Oban.Testing.html#module-matching-timestamps)
 
 #### Enqueue in a transaction
 

--- a/notebooks/04_refunding_an_order.livemd
+++ b/notebooks/04_refunding_an_order.livemd
@@ -79,7 +79,7 @@ In this exercise you'll learn how to prevent duplicate jobs with unique options,
 
 Inevitably, some customers will be unhappy with an order and they'll want to get their money back. Refunds are a delicate operation because money is involved and we want to guarantee there aren't duplicate transactions—while keeping the operation in a reliable background job.
 
-This is where [unique jobs](https://hexdocs.pm/oban/Oban.html#module-unique-jobs) come in.
+This is where [unique jobs](https://hexdocs.pm/oban/unique_jobs.html) come in.
 
 To begin, define a `Refunder` worker that takes an order id and a refund reason as args, fetches the order, and calls `ChowMojo.refund_order/2` to refund the money.
 
@@ -111,7 +111,7 @@ So far we have an ordinary worker like the ones we've written in previous exerci
 
 Modify the `Refunder` worker to be unique forever and write a test that verifies only one refund job may exist for an order, even with different reasons.
 
-An `Oban` instance is started for `:manual` testing where jobs are inserted into the database rather than executing immediately. Your tests should insert multiple jobs with the same order id, and maybe the same reason, then use [`all_enqueued/1`](https://hexdocs.pm/oban/Oban.Testing.html#all_enqueued/2) to ensure there aren't duplicates.
+An `Oban` instance is started for `:manual` testing where jobs are inserted into the database rather than executing immediately. Your tests should insert multiple jobs with the same order id, and maybe the same reason, then use [`all_enqueued/1`](https://hexdocs.pm/oban/Oban.Testing.html#all_enqueued/1) to ensure there aren't duplicates.
 
 <details>
 <summary><i>Use a hint</i></summary>
@@ -242,11 +242,11 @@ Use [retry_job/1,2](https://hexdocs.pm/oban/Oban.html#retry_job/2) or [retry_all
 
 #### Debouncing with replace
 
-Sometimes customers are hasty and click to refund before they've written a reason. To compensate for unpredictable customers, schedule refunds for 10 minutes after they're requested and use [replace](https://hexdocs.pm/oban/Oban.html#module-unique-jobs) to reschedule farther in the future.
+Sometimes customers are hasty and click to refund before they've written a reason. To compensate for unpredictable customers, schedule refunds for 10 minutes after they're requested and use [replace](https://hexdocs.pm/oban/unique_jobs.html#replacing-values) to reschedule farther in the future.
 
 The `replace` option can only be used when building a job, not when defining the worker. That means you must pass it as an option to `Refunder.new/2`, _or_ override the `Refunder.new/2` callback function to automatically inject `replace` options.
 
-Write a test to [verify that the job's `scheduled_at` time changes](https://hexdocs.pm/oban/Oban.Testing.html#module-matching-scheduled-jobs-and-timestamps).
+Write a test to [verify that the job's `scheduled_at` time changes](https://hexdocs.pm/oban/Oban.Testing.html#module-matching-timestamps).
 
 <!-- livebook:{"break_markdown":true} -->
 

--- a/notebooks/05_delivering_a_daily_digest.livemd
+++ b/notebooks/05_delivering_a_daily_digest.livemd
@@ -194,9 +194,9 @@ ExUnit.run()
 
 With confidence that the worker delivers digests to the correct restaurants, we're ready to automate delivery on a schedule.
 
-The ideal way to [schedule periodic jobs](https://hexdocs.pm/oban/Oban.html#module-periodic-jobs) is with the [Cron plugin](https://hexdocs.pm/oban/Oban.Plugins.Cron.html). In Oban, plugins are processes (GenServers) that insert, update, or delete jobs autonomously based on some configuration. We'll look at other plugins and their role in production systems later on.
+The ideal way to [schedule periodic jobs](https://hexdocs.pm/oban/periodic_jobs.html) is with the [Cron plugin](https://hexdocs.pm/oban/Oban.Plugins.Cron.html). In Oban, plugins are processes (GenServers) that insert, update, or delete jobs autonomously based on some configuration. We'll look at other plugins and their role in production systems later on.
 
-For now, let's define options for an Oban instance with a Cron plugin that schedules a `DailyDigest` job every minute and starts an `email` [queue in the paused state](https://hexdocs.pm/oban/Oban.html#module-configuring-queues). Note that we're scheduling jobs frequently for testing purposes, in reality we'd want to deliver digest emails once a day.
+For now, let's define options for an Oban instance with a Cron plugin that schedules a `DailyDigest` job every minute and starts an `email` [queue in the paused state](https://hexdocs.pm/oban/defining_queues.html). Note that we're scheduling jobs frequently for testing purposes, in reality we'd want to deliver digest emails once a day.
 
 At this point we're only validating the config, not starting the instance.
 

--- a/notebooks/06_backfilling_reviews.livemd
+++ b/notebooks/06_backfilling_reviews.livemd
@@ -211,7 +211,7 @@ Jobs usually execute in order they're scheduled with the `id` as a secondary sor
 | 3   | 2023-09-03 00:00:02 |
 | 4   | 2023-09-03 00:00:02 |
 
-We say "usually" because it's possible to [change a job's priority](https://hexdocs.pm/oban/Oban.html#module-prioritizing-jobs) so that it runs before or after other jobs, regardless of when they were scheduled. The default priority is 0, and jobs with a higher value have a lower priority (like `nice` for OS processes). Rewriting the table above so that only job `4` is priority 0:
+We say "usually" because it's possible to [change a job's priority](https://hexdocs.pm/oban/Oban.Worker.html#module-prioritizing-jobs) so that it runs before or after other jobs, regardless of when they were scheduled. The default priority is 0, and jobs with a higher value have a lower priority (like `nice` for OS processes). Rewriting the table above so that only job `4` is priority 0:
 
 | priority | id  | scheduled_at        |
 | -------- | --- | ------------------- |


### PR DESCRIPTION
I noticed that there are some links that changed in the last version of the doc (changed the name of the fragment `#` or changed that section of the doc and now it is somewhere else), so I took as reference the [v2.15.4](https://hexdocs.pm/oban/2.15.4/Oban.html) where all the links are valid and corrected them.

Also i fox the link to the oban repo was pointing to an empty line and I guess it should be in the supervisor part.

